### PR TITLE
fix compile warning for lack string.h head file and add install and uninstall target with Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,16 @@
 # png2c - Oleg Vaskevich
-png2c: png2c.c
-	gcc -o png2c png2c.c -I. -lpng
+TARGET := png2c
+SRC = png2c.c
+
+$(TARGET): $(SRC)
+	gcc -o $@ $^ -lpng
+
+install:
+	@cp -frv $(TARGET) /usr/local/bin
+
+uninstall:
+	@rm -frv /usr/local/bin/$(TARGET)
 
 clean:
-	rm -f png2c
+	rm -f $(TARGET)
 

--- a/png2c.c
+++ b/png2c.c
@@ -13,6 +13,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <png.h>
+#include <string.h>
 
 #define RGB888toRGB565(r, g, b) ((r >> 3) << 11)| \
 	((g >> 2) << 5)| ((b >> 3) << 0)


### PR DESCRIPTION
When i compile the tool, i catch the compile warning as below
```
png2c.c:57:27: warning: implicit declaration of function ‘strcmp’ [-Wimplicit-function-declaration]
   57 |     if (argc == 3 && 0 == strcmp(argv[2], "-a"))
      |                           ^~~~~~
png2c.c:125:18: warning: implicit declaration of function ‘strlen’ [-Wimplicit-function-declaration]
  125 |     size_t len = strlen(argv[1]);
      |                  ^~~~~~
png2c.c:125:18: warning: incompatible implicit declaration of built-in function ‘strlen’
png2c.c:16:1: note: include ‘<string.h>’ or provide a declaration of ‘strlen’
   15 | #include <png.h>
  +++ |+#include <string.h>
   16 |
png2c.c:127:5: warning: implicit declaration of function ‘memcpy’ [-Wimplicit-function-declaration]
  127 |     memcpy(imageName, argv[1], len - 4);
      |     ^~~~~~
png2c.c:127:5: warning: incompatible implicit declaration of built-in function ‘memcpy’
```
i fix the compile warning by add **string.h** head file.
Besides i do some change with the Makefile, add **install** and **uninstall** target.
